### PR TITLE
Php small fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ allprojects {
     repositories {
         mavenCentral()
         maven(url = "https://packages.jetbrains.team/maven/p/astminer/astminer")
+        maven("https://packages.jetbrains.team/maven/p/big-code/bigcode")
     }
 
     dependencies {
@@ -31,20 +32,16 @@ allprojects {
         implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.4.1")
         implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
         implementation("it.unimi.dsi:fastutil:8.5.9")
+        implementation("org.jetbrains.research:plugin-utilities-core:1.0") {
+            exclude("org.slf4j", "slf4j-simple")
+            exclude("org.slf4j", "slf4j-api")
+            exclude("org.slf4j", "slf4j")
+        }
 
         testImplementation(platform("org.junit:junit-bom:5.9.0"))
         testImplementation("org.junit.jupiter:junit-jupiter:5.9.0")
 
         detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.18.1")
-
-        implementation("${getProperty("utilitiesProjectName")}:plugin-utilities-core") {
-            version {
-                branch = getProperty("utilitiesBranch")
-            }
-            exclude("org.slf4j", "slf4j-simple")
-            exclude("org.slf4j", "slf4j-api")
-            exclude("org.slf4j", "slf4j")
-        }
     }
 
     configurations.all {

--- a/psiminer-cli/build.gradle.kts
+++ b/psiminer-cli/build.gradle.kts
@@ -15,7 +15,8 @@ tasks {
         args = listOfNotNull("psiminer", dataset, output, config)
         jvmArgs = listOf(
             "-Djava.awt.headless=true", "-Djdk.module.illegalAccess.silent=true",
-            "--add-exports", "java.base/jdk.internal.vm=ALL-UNNAMED", "-Xmx32G"
+            "--add-exports", "java.base/jdk.internal.vm=ALL-UNNAMED", "-Xmx32G",
+            "-Didea.is.internal=false", "-Dlog4j.configurationFile=psiminer-cli/src/main/resources/log4j.properties"
         )
         maxHeapSize = "32g"
     }

--- a/psiminer-cli/src/main/resources/log4j.properties
+++ b/psiminer-cli/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Define the root logger with appender file
-log4j.rootLogger=WARN, FILE
+log4j.rootLogger=SEVERE, FILE
 
 # Define the file appender
 log4j.appender.FILE=org.apache.log4j.FileAppender

--- a/psiminer-core/src/main/kotlin/psi/graphs/edgeProviders/php/PhpControlFlowEdgeProvider.kt
+++ b/psiminer-core/src/main/kotlin/psi/graphs/edgeProviders/php/PhpControlFlowEdgeProvider.kt
@@ -3,7 +3,6 @@ package psi.graphs.edgeProviders.php
 import com.intellij.psi.PsiElement
 import com.intellij.psi.controlFlow.*
 import com.jetbrains.php.codeInsight.controlFlow.PhpControlFlow
-import com.jetbrains.php.codeInsight.controlFlow.instructions.PhpExitPointInstruction
 import com.jetbrains.php.codeInsight.controlFlow.instructions.PhpInstruction
 import com.jetbrains.php.lang.psi.elements.ControlStatement
 import com.jetbrains.php.lang.psi.elements.PhpReturn
@@ -77,7 +76,6 @@ class PhpControlFlowEdgeProvider : EdgeProvider(
 
     private fun provideEdgesForInstruction(
         index: Int,
-        instructions: List<PhpInstruction>,
         elements: List<PsiElement?>,
         successors: Array<out Set<Int>>,
         nextNonBranchingInstructions: Array<out Set<Int>>,
@@ -101,7 +99,7 @@ class PhpControlFlowEdgeProvider : EdgeProvider(
                 newEdges.add(Edge(element, toElement, EdgeType.ControlElement))
             }
         }
-        if (element is PhpReturn || isTerminalInstruction(index, instructions, successors)) {
+        if (isTerminalInstruction(index, elements, successors)) {
             addReturnsToEdge(element, elements, newEdges)
         }
         return newEdges
@@ -109,11 +107,11 @@ class PhpControlFlowEdgeProvider : EdgeProvider(
 
     private fun isTerminalInstruction(
         index: Int,
-        instructions: List<PhpInstruction>,
+        elements: List<PsiElement?>,
         successors: Array<out Set<Int>>,
     ): Boolean =
         successors[index].isEmpty() ||
-                successors[index].map { instructions[it] }.any { it is PhpExitPointInstruction }
+                successors[index].map { elements[it] }.all { it == null }
 
     private fun addReturnsToEdge(
         element: PsiElement,
@@ -139,7 +137,7 @@ class PhpControlFlowEdgeProvider : EdgeProvider(
         val nextNonBranchingInstructions = computeNextNonBranchingInstructions(instructions, elements, successors)
         instructions.indices.forEach { index ->
             newEdges.addAll(
-                provideEdgesForInstruction(index, instructions, elements, successors, nextNonBranchingInstructions)
+                provideEdgesForInstruction(index, elements, successors, nextNonBranchingInstructions)
             )
         }
     }

--- a/psiminer-core/src/test/resources/data/php/PhpFlowMethods.php
+++ b/psiminer-core/src/test/resources/data/php/PhpFlowMethods.php
@@ -82,4 +82,14 @@ class PhpFlowMethods
         }
         return 2;
     }
+
+    public function forWithReturn()
+    {
+        for ($i = 0; $i < 2; $i++) {
+            if ($i == 1) {
+                return;
+            }
+        }
+        $e = 5;
+    }
 }


### PR DESCRIPTION
**A small update on PHP mining**:
1. Resolve this issue: https://github.com/JetBrains-Research/psiminer/issues/40
2. Change the way of mining ReturnsTo edges. Before there used to be more edges than necessary, now we have an edge for every return statement and the edge from the last instruction (in case it's not a return statement). Add tests for clarity.
3. Fix the issue with spamming logs while running on CodeSearchNet dataset by passing "-Didea.is.internal=false" to JVM args.